### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# ConsenSys documentation team
-/snaps/ @alexandratran @bgravenorst
-/wallet/ @alexandratran @bgravenorst
+/snaps/ @alexandratran @bgravenorst @ziad-saab
+/wallet/ @alexandratran @bgravenorst @GuiBibeau


### PR DESCRIPTION
Add codeowners file automatically requesting reviews from the ConsenSys doc team (@bgravenorst and myself) if any changes are made to the folders containing doc content.