### PR TITLE
Fixes preview builds

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,6 +6,9 @@ on:
       destination_dir:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
 
 jobs:
   publish-docs-to-gh-pages:
@@ -19,6 +22,8 @@ jobs:
         run: exit 1
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -50,7 +50,8 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: preview/${{ needs.get-commit-hash.outputs.COMMIT_SHA }}
-  
+      ref: ${{ needs.get-commit-hash.outputs.COMMIT_SHA }}
+
   post-preview-comment:
     name: Post preview in comment
     needs:


### PR DESCRIPTION
the github checkout action gets a default value for `ref` that is correct only when the action is triggered by a branch action. It seems that the comment event does not set this default correctly, and causes the preview to be built from the `main` branch.

this PR sets the `ref` option explicily to the commit sha of the preview builds' head

fixes #49 