### PR TITLE
Fix preview publishing

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -37,7 +37,7 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Get commit SHA
         id: commit-sha
-        run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "COMMIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Ensure commit hash is not empty
         if: ${{ steps.commit-sha.outputs.COMMIT_SHA == '' }}
         run: exit 1


### PR DESCRIPTION
Preview publishing was broken because we were trying to use a short commit hash as the `ref` to checkout with `actions/checkout@v3`. But `actions/checkout@v3` only supports full commit hashes.

Instead we now pass it a full hash. Unfortunately this means that the preview build URLs will be quite a bit longer, but hopefully this is OK. If not, we can update this to generate both hashes.