### PR TITLE
Add a tip about using wallet_getPermissions to get all permitted accounts

### DIFF
--- a/wallet/get-started/access-accounts.md
+++ b/wallet/get-started/access-accounts.md
@@ -82,6 +82,15 @@ async function getAccount() {
 </TabItem>
 </Tabs>
 
+:::caution important
+At the moment, MetaMask returns at most one account in the array.
+The array may return more than one account in the future.
+:::
+
+:::tip
+To retrieve the full list of accounts for which the user has permitted access, use the [`wallet_getPermissions`](../reference/rpc-api#wallet_getpermissions) method.
+:::
+
 ## Handle accounts
 
 Use the [`eth_accounts`](https://metamask.github.io/api-playground/api-documentation/#eth_accounts)
@@ -123,7 +132,7 @@ function handleAccountsChanged(accounts) {
 ```
 
 :::note
-In the future, the accounts array may contain more than one account.
-This functionality isn't available yet.
-The first account in the array will always be considered the user's "selected" account.
+The first account in the array will always be considered the user's "selected" account. The array may return more than one account in the future.
 :::
+
+

--- a/wallet/get-started/access-accounts.md
+++ b/wallet/get-started/access-accounts.md
@@ -135,5 +135,3 @@ MetaMask currently returns at most one account in the `accounts` array.
 The array may contain more than one account in the future.
 The first account in the array will always be considered the user's "selected" account.
 :::
-
-

--- a/wallet/get-started/access-accounts.md
+++ b/wallet/get-started/access-accounts.md
@@ -82,13 +82,12 @@ async function getAccount() {
 </TabItem>
 </Tabs>
 
-:::caution important
-At the moment, MetaMask returns at most one account in the array.
-The array may return more than one account in the future.
-:::
+:::note
+MetaMask currently returns at most one account in the `accounts` array.
+The array may contain more than one account in the future.
 
-:::tip
-To retrieve the full list of accounts for which the user has permitted access, use the [`wallet_getPermissions`](../reference/rpc-api#wallet_getpermissions) method.
+To retrieve the full list of accounts for which the user has permitted access, use the
+[`wallet_getPermissions`](../reference/rpc-api#wallet_getpermissions) RPC method.
 :::
 
 ## Handle accounts
@@ -132,7 +131,9 @@ function handleAccountsChanged(accounts) {
 ```
 
 :::note
-The first account in the array will always be considered the user's "selected" account. The array may return more than one account in the future.
+MetaMask currently returns at most one account in the `accounts` array.
+The array may contain more than one account in the future.
+The first account in the array will always be considered the user's "selected" account.
 :::
 
 


### PR DESCRIPTION
Update the admonitions for accounts to inform developers that they can use wallet_getPermissions to get around the single account limit on the return value from eth_requestAccounts

fixes #63 