### PR TITLE
Update support links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,6 +152,10 @@ const config = {
                 href: "https://discord.gg/consensys",
               },
               {
+                label: "Snaps GitHub discussions",
+                href: "https://github.com/MetaMask/snaps-monorepo/discussions",
+              },
+              {
                 label: "Documentation requests",
                 href: "https://github.com/MetaMask/mm-docs-v2/issues/new",
               },

--- a/snaps/index.md
+++ b/snaps/index.md
@@ -39,5 +39,6 @@ For example, you can:
 
 ## Questions?
 
-If you have questions or want to propose a new feature, you can interact with the Snaps team and
-community on [GitHub discussions](https://github.com/MetaMask/snaps-skunkworks/discussions).
+If you have questions about using Snaps or want to propose a new feature, you can interact with the
+Snaps team and community on [GitHub discussions](https://github.com/MetaMask/snaps-monorepo/discussions)
+and the Snaps channel on [ConsenSys Discord](https://discord.gg/consensys).

--- a/wallet/index.md
+++ b/wallet/index.md
@@ -40,4 +40,7 @@ Mobile wallet using a QR code.
 For dapps running on a mobile browser, MetaMask SDK automatically deeplinks to the user's MetaMask
 Mobile wallet to make the connection.
 
-If you have questions about the SDK, you can join the [MetaMask SDK Discord](https://discord.gg/N3jSkZbYm6).
+## Questions?
+
+If you have questions about integrating your dapp with MetaMask, you can interact with the MetaMask
+team and community on the MetaMask channels on [ConsenSys Discord](https://discord.gg/consensys).


### PR DESCRIPTION
Update support links to include a clear **Questions?** section to each index page, remove SDK discord, and add Snaps GitHub discussions to the footer.