### PR TITLE
Add Linea to default networks list

### DIFF
--- a/wallet/get-started/detect-network.md
+++ b/wallet/get-started/detect-network.md
@@ -36,4 +36,5 @@ Consult [chainid.network](https://chainid.network) for more.
 | 0x1      | 1        | Ethereum main network (Mainnet)                                           |
 | 0x5      | 5        | Goerli test network                                                       |
 | 0xaa36a7 | 11155111 | Sepolia test network                                                      |
+| 0xe704   | 59140    | [Linea Goerli test network](https://docs.linea.build/)                    |
 | 0x539    | 1337     | Localhost test networks (including [Ganache](run-development-network.md)) |


### PR DESCRIPTION
Add Linea Goerli test network to default networks list. Fixes #96.