### PR TITLE
[Snaps] Document `endowment:webassembly` permission

### DIFF
--- a/snaps/concepts/execution-environment.md
+++ b/snaps/concepts/execution-environment.md
@@ -18,11 +18,13 @@ The following globals are also available:
 
 - `console`
 - `crypto`
-- `fetch` / `WebSocket` (with the [appropriate permission](../how-to/request-permissions.md#endowmentnetwork-access))
+- `fetch` / `WebSocket` (with the
+  [`endowment:network-access`](../reference/permissions.md#endowment--network-access) permission)
 - `setTimeout` / `clearTimeout`
 - `setInterval` / `clearInterval`
 - `SubtleCrypto`
-- `WebAssembly`
+- `WebAssembly` (with the
+  [`endowment:webassembly`](../reference/permissions.md#endowment--webassembly) permission)
 - `TextEncoder` / `TextDecoder`
 - `atob` / `btoa`
 - `URL`

--- a/snaps/reference/permissions.md
+++ b/snaps/reference/permissions.md
@@ -140,3 +140,16 @@ Specify this permission in the manifest file as follows:
   }
 },
 ```
+
+## endowment:webassembly
+
+To use WebAssembly, a snap must request the `endowment:webassembly` permission.
+This permission exposes the global `WebAssembly` API to the snap execution environment.
+
+Specify this permission in the manifest file as follows:
+
+```json
+"initialPermissions": {
+  "endowment:webassembly": {}
+},
+```


### PR DESCRIPTION
Migrate and edit the changes from https://github.com/MetaMask/metamask-docs/pull/691, documenting the `endowment:webassembly` Snaps permission. To be merged when Flask `10.28.1` goes out.