### PR TITLE
Document `wallet_snap`

### DIFF
--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -8,20 +8,19 @@ import TabItem from '@theme/TabItem';
 # Snaps JSON-RPC API
 
 Snaps communicate with MetaMask using the Snaps JSON-RPC API.
-These API methods allow snaps to modify the functionality of MetaMask, and websites (dapps) to
-install and communicate with individual snaps.
-Some methods are only callable by snaps, and some are only callable by websites.
+These API methods allow snaps to modify the functionality of MetaMask, and dapps to install and
+communicate with individual snaps.
+Some methods are only callable by snaps, and some are only callable by dapps.
 
 ## Unrestricted methods
 
-You can use unrestricted methods without [requesting permission](../how-to/request-permissions.md)
-to do so.
+Snaps and dapps don't need to request permission to call unrestricted methods.
 
 ### wallet_getSnaps
 
 Returns the IDs of the caller's permitted snaps and some relevant metadata.
 
-This method is only callable by websites.
+This method is only callable by dapps.
 
 #### Returns
 
@@ -78,7 +77,7 @@ the request is rejected.
 Snaps are fully responsible for implementing their JSON-RPC API.
 Consult the snap's documentation for available methods, their parameters, and return values.
 
-This method is only callable by websites.
+This method is only callable by dapps.
 
 #### Parameters
 
@@ -120,7 +119,7 @@ If an incompatible version is installed, MetaMask attempts to update the snap to
 that satisfies the requested range.
 The request succeeds if the snap is successfully updated.
 
-This method is only callable by websites.
+This method is only callable by dapps.
 
 #### Parameters
 
@@ -179,9 +178,10 @@ try {
 
 ## Restricted methods
 
-You must
-[request permission](../how-to/request-permissions.md#rpc-api-permissions) in the snap manifest file
-to use a restricted method.
+For restricted methods callable by snaps, a snap must request permission to call the method in the
+[snap manifest file](../how-to/request-permissions.md).
+For restricted methods callable by dapps, a dapp must request permission to call the method using
+[`wallet_requestPermissions`](../../wallet/reference/rpc-api#walletrequestpermissions).
 
 ### snap_confirm (deprecated)
 
@@ -722,7 +722,7 @@ await snap.request({
 });
 ```
 
-### wallet\_snap\_*
+### wallet_snap
 
 Invokes the specified JSON-RPC method of the snap corresponding to the specified permission name.
 The snap must be installed and the caller must have permission to communicate with the snap, or the
@@ -731,7 +731,7 @@ request is rejected.
 Snaps are responsible for implementing their JSON-RPC API.
 Consult the snap's documentation for available methods, their parameters, and return values.
 
-This method is only callable by websites.
+This method is only callable by dapps.
 
 :::note
 This is a namespaced method.

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -715,7 +715,8 @@ await snap.request({
 A website must request the `wallet_snap` permission using
 [`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
 interact with the specified snaps.
-Requesting this permission also invokes the specified snaps.
+
+A website can also call this method to invoke the specified JSON-RPC method of the specified snap.
 
 This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap), and is only callable by websites.
 
@@ -734,7 +735,16 @@ Specify each snap to request permission to interact with as an entry in the `val
 Each snap entry can include a `version` to install.
 The default is the latest version.
 
+When calling this method, it takes as a parameter one object containing:
+
+- `snapId` - The ID of the snap to invoke.
+- `request` - The JSON-RPC request object to send to the invoked snap.
+
 #### Example
+
+<!--tabs-->
+
+# wallet_requestPermissions
 
 The following is an example of calling `wallet_requestPermissions` to request the `wallet_snap`
 permission:
@@ -757,3 +767,23 @@ const result = await ethereum.request({
   }],
 });
 ```
+
+# wallet_snap
+
+The following is an example of calling `wallet_snap`:
+
+```javascript
+const result = await ethereum.request({
+  method: 'wallet_snap',
+  params: {
+    snapId: 'npm:@metamask/example-snap',
+    request: {
+      method: 'hello',
+    },
+  },
+});
+
+console.log(result); // In this example, the result is a boolean.
+```
+
+<!--/tabs-->

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -50,7 +50,7 @@ console.log(result);
 {
   'npm:@metamask/example-snap': {
     version: '1.0.0',
-    id: 'npm@metamask/example-snap',
+    id: 'npm:@metamask/example-snap',
     enabled: true,
     blocked: false,
   },
@@ -153,13 +153,13 @@ try {
 {
   'npm:@metamask/example-snap': {
     version: '1.0.0',
-    id: 'npm@metamask/example-snap',
+    id: 'npm:@metamask/example-snap',
     enabled: true,
     blocked: false,
   },
   'npm:fooSnap': {
     version: '1.0.5',
-    id: 'npmfooSnap',
+    id: 'npm:fooSnap',
     enabled: true,
     blocked: false,
   },
@@ -748,8 +748,8 @@ const result = await ethereum.request({
         {
           type: 'snapIds',
           value: {
-            '@metamask/example-snap': { version: '1.0.0' },
-            '@metamask/foo-bar-snap': { version: '1.2.1' },
+            'npm:@metamask/example-snap': { version: '1.0.0' },
+            'npm:@metamask/foo-bar-snap': { version: '1.2.1' },
           }
         }
       ]

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -5,9 +5,9 @@ description: Snaps JSON-RPC API reference
 # Snaps JSON-RPC API
 
 Snaps communicate with MetaMask using the Snaps JSON-RPC API.
-These API methods allow snaps to modify the functionality of MetaMask, and dapps to install and
-communicate with individual snaps.
-Some methods are only callable by snaps, and some are only callable by dapps.
+These API methods allow snaps to modify the functionality of MetaMask, and websites (dapps) to
+install and communicate with individual snaps.
+Some methods are only callable by snaps, and some are only callable by websites.
 
 ## Unrestricted methods
 
@@ -17,7 +17,7 @@ You can call unrestricted methods without requesting permission to do so.
 
 Returns the IDs of the caller's permitted snaps and some relevant metadata.
 
-This method is only callable by dapps.
+This method is only callable by websites.
 
 #### Returns
 
@@ -73,7 +73,7 @@ the request is rejected.
 Snaps are fully responsible for implementing their JSON-RPC API.
 Consult the snap's documentation for available methods, their parameters, and return values.
 
-This method is only callable by dapps.
+This method is only callable by websites.
 
 #### Parameters
 
@@ -115,7 +115,7 @@ If an incompatible version is installed, MetaMask attempts to update the snap to
 that satisfies the requested range.
 The request succeeds if the snap is successfully updated.
 
-This method is only callable by dapps.
+This method is only callable by websites.
 
 #### Parameters
 
@@ -175,7 +175,7 @@ try {
 
 For restricted methods callable by snaps, a snap must request permission to call the method in the
 [snap manifest file](../how-to/request-permissions.md).
-For restricted methods callable by dapps, a dapp must request permission to call the method using
+For restricted methods callable by websites, a website must request permission to call the method using
 [`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions).
 
 ### snap_confirm (deprecated)
@@ -716,11 +716,11 @@ await snap.request({
 ### wallet_snap
 
 Invokes the specified JSON-RPC method of the specified snap.
-A dapp must request permission to call this method using
+A website must request permission to call this method using
 [`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
 interact with the specified snap.
 
-This method is only callable by dapps.
+This method is only callable by websites.
 
 #### Parameters
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -715,36 +715,48 @@ await snap.request({
 
 ### wallet_snap
 
-Invokes the specified JSON-RPC method of the specified snap.
-A website must request permission to call this method using
+A website must request the `wallet_snap` permission using
 [`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
-interact with the specified snap.
+interact with the specified snaps.
+Requesting this permission also installs the specified snaps, if not installed already.
 
-This method is only callable by websites.
+This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap), and is only callable by websites.
+
+:::note
+Most websites only ever make one call to `wallet_requestPermissions`.
+Consecutive calls to `wallet_requestPermissions` for the `wallet_snap` permission overwrites a
+website's existing permissions to interact with snaps.
+To deal with this, you must write custom logic to merge existing snap IDs with new ones you're requesting.
+Use [`wallet_getSnaps`](#wallet_getsnaps) to get a list of a website's permitted snaps.
+:::
 
 #### Parameters
 
-An object containing:
-
-- `snapId` - The ID of the snap to invoke.
-- `request` - The JSON-RPC request object to send to the invoked snap.
-
-#### Returns
-
-The result of the snap method call.
+When requesting this permission, specify a caveat of type `snapIds`.
+Specify each snap to request permission to interact with as an entry in the `value` field.
+Each snap entry can include a `version` to install.
+The default is the latest version.
 
 #### Example
 
+The following is an example of calling `wallet_requestPermissions` to request the `wallet_snap`
+permission:
+
 ```javascript
 const result = await ethereum.request({
-  method: 'wallet_snap',
-  params: {
-    snapId: '@metamask/example-snap',
-    request: {
-      method: 'hello',
-    },
-  },
+  method: 'wallet_requestPermissions',
+  params: [{
+    wallet_snap: {
+      caveats: [
+        {
+          type: 'snapIds',
+          value: {
+            '@metamask/example-snap': { version: '1.0.0' },
+            '@metamask/foo-bar-snap': { version: '1.2.1' },
+          }
+        }
+      ]
+    }
+  }],
 });
-
-console.log(result); // In this example, the result is a boolean.
 ```

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -176,7 +176,7 @@ try {
 For restricted methods callable by snaps, a snap must request permission to call the method in the
 [snap manifest file](../how-to/request-permissions.md).
 For restricted methods callable by dapps, a dapp must request permission to call the method using
-[`wallet_requestPermissions`](../../wallet/reference/rpc-api#walletrequestpermissions).
+[`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions).
 
 ### snap_confirm (deprecated)
 
@@ -717,7 +717,7 @@ await snap.request({
 
 Invokes the specified JSON-RPC method of the specified snap.
 A dapp must request permission to call this method using
-[`wallet_requestPermissions`](../../wallet/reference/rpc-api#walletrequestpermissions) in order to
+[`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
 interact with the specified snap.
 
 This method is only callable by dapps.

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -50,12 +50,12 @@ console.log(result);
   accountRPC methods?s: ['0xa...', '0xb...'],
   permissions: {
     eth_accounts: {},
-    'wallet_snap_npm:@metamask/example-snap': {},
+    wallet_snap: {},
   },
   snaps: {
     'npm:@metamask/example-snap': {
       version: '1.0.0',
-      permissionName: 'wallet_snap_npm:@metamask/example-snap',
+      permissionName: 'wallet_snap',
       ...
     }
   }
@@ -158,12 +158,12 @@ try {
 {
   'npm:@metamask/example-snap': {
     version: '1.0.0',
-    permissionName: 'wallet_snap_npm:@metamask/example-snap',
+    permissionName: 'wallet_snap',
     ...
   },
   'npm:fooSnap': {
     version: '1.0.5',
-    permissionName: 'wallet_snap_npm:fooSnap',
+    permissionName: 'wallet_snap',
     ...
   },
 }

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -713,7 +713,7 @@ await snap.request({
 ### wallet_snap
 
 A website must request the `wallet_snap` permission using
-[`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
+[`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) to
 interact with the specified snaps.
 
 A website can also call this method to invoke the specified JSON-RPC method of the specified snap.
@@ -721,7 +721,7 @@ A website can also call this method to invoke the specified JSON-RPC method of t
 This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap), and is only callable by websites.
 
 :::note
-Most websites only ever make one call to `wallet_requestPermissions`.
+Most websites only make one call to `wallet_requestPermissions`.
 Consecutive calls to `wallet_requestPermissions` for the `wallet_snap` permission overwrites a
 website's existing permissions to interact with snaps.
 To deal with this, you must write custom logic to merge existing snap IDs with new ones you're requesting.
@@ -735,7 +735,7 @@ Specify each snap to request permission to interact with as an entry in the `val
 Each snap entry can include a `version` to install.
 The default is the latest version.
 
-When calling this method, it takes as a parameter one object containing:
+When calling this method, specify an object containing:
 
 - `snapId` - The ID of the snap to invoke.
 - `request` - The JSON-RPC request object to send to the invoked snap.

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -27,8 +27,9 @@ Each snap is an object containing:
 - `id` - The ID of the snap.
 - `initialPermissions` - The initial permissions of the snap, which will be requested when the snap
   is installed.
-- `permissionName` - The name of the permission used to invoke the snap.
 - `version` - The version of the snap.
+- `enabled` - `true` if the snap is enabled, `false` otherwise.
+- `blocked` - `true` if the snap is blocked, `false` otherwise.
 
 #### Example
 
@@ -47,18 +48,12 @@ console.log(result);
 ```javascript
 // Example result if any snaps are permitted
 {
-  accountRPC methods?s: ['0xa...', '0xb...'],
-  permissions: {
-    eth_accounts: {},
-    wallet_snap: {},
+  'npm:@metamask/example-snap': {
+    version: '1.0.0',
+    id: 'npm@metamask/example-snap',
+    enabled: true,
+    blocked: false,
   },
-  snaps: {
-    'npm:@metamask/example-snap': {
-      version: '1.0.0',
-      permissionName: 'wallet_snap',
-      ...
-    }
-  }
 }
 ```
 
@@ -158,13 +153,15 @@ try {
 {
   'npm:@metamask/example-snap': {
     version: '1.0.0',
-    permissionName: 'wallet_snap',
-    ...
+    id: 'npm@metamask/example-snap',
+    enabled: true,
+    blocked: false,
   },
   'npm:fooSnap': {
     version: '1.0.5',
-    permissionName: 'wallet_snap',
-    ...
+    id: 'npmfooSnap',
+    enabled: true,
+    blocked: false,
   },
 }
 ```
@@ -718,7 +715,7 @@ await snap.request({
 A website must request the `wallet_snap` permission using
 [`wallet_requestPermissions`](../../wallet/reference/rpc-api#wallet_requestpermissions) in order to
 interact with the specified snaps.
-Requesting this permission also installs the specified snaps, if not installed already.
+Requesting this permission also invokes the specified snaps.
 
 This method is synonymous to [`wallet_invokeSnap`](#wallet_invokesnap), and is only callable by websites.
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -11,7 +11,7 @@ Some methods are only callable by snaps, and some are only callable by dapps.
 
 ## Unrestricted methods
 
-Snaps and dapps don't need to request permission to call unrestricted methods.
+You can call unrestricted methods without requesting permission to do so.
 
 ### wallet_getSnaps
 
@@ -707,35 +707,27 @@ An object containing the contents of the notification:
 await snap.request({
   method: 'snap_notify',
   params: {
-      type: 'inApp',
-      message: `Hello, world!`,
+    type: 'inApp',
+    message: 'Hello, world!',
   },
 });
 ```
 
 ### wallet_snap
 
-Invokes the specified JSON-RPC method of the snap corresponding to the specified permission name.
-The snap must be installed and the caller must have permission to communicate with the snap, or the
-request is rejected.
-
-Snaps are responsible for implementing their JSON-RPC API.
-Consult the snap's documentation for available methods, their parameters, and return values.
+Invokes the specified JSON-RPC method of the specified snap.
+A dapp must request permission to call this method using
+[`wallet_requestPermissions`](../../wallet/reference/rpc-api#walletrequestpermissions) in order to
+interact with the specified snap.
 
 This method is only callable by dapps.
 
-:::note
-This is a namespaced method.
-The `*` in the name is always substituted for a string, in this case a snap ID.
-:::
-
-:::tip
-[`wallet_invokeSnap`](#walletinvokesnap) provides a more convenient way of calling this method.
-:::
-
 #### Parameters
 
-The JSON-RPC request object to send to the invoked snap.
+An object containing:
+
+- `snapId` - The ID of the snap to invoke.
+- `request` - The JSON-RPC request object to send to the invoked snap.
 
 #### Returns
 
@@ -745,9 +737,12 @@ The result of the snap method call.
 
 ```javascript
 const result = await ethereum.request({
-  method: 'wallet_snap_npm:@metamask/example-snap',
+  method: 'wallet_snap',
   params: {
-    method: 'hello',
+    snapId: '@metamask/example-snap',
+    request: {
+      method: 'hello',
+    },
   },
 });
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -733,7 +733,7 @@ Use [`wallet_getSnaps`](#wallet_getsnaps) to get a list of a website's permitted
 #### Parameters
 
 When requesting this permission, specify a caveat of type `snapIds`.
-Specify each snap to request permission to interact with as an entry in the `value` field.
+Specify each snap to request permission to interact with as an entry in the `value` field of the caveat.
 Each snap entry can include a `version` to install.
 The default is the latest version.
 

--- a/snaps/reference/rpc-api.md
+++ b/snaps/reference/rpc-api.md
@@ -740,6 +740,10 @@ When calling this method, it takes as a parameter one object containing:
 - `snapId` - The ID of the snap to invoke.
 - `request` - The JSON-RPC request object to send to the invoked snap.
 
+#### Returns
+
+Result of the snap method call.
+
 #### Example
 
 <!--tabs-->

--- a/wallet/reference/rpc-api.md
+++ b/wallet/reference/rpc-api.md
@@ -35,7 +35,7 @@ Make sure to handle errors for every call to
 
 MetaMask introduced web3 wallet permissions in [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255).
 In this permissions system, each RPC method is restricted or unrestricted.
-If a method is restricted, the caller must request permission to call it using
+If a method is restricted, a dapp must request permission to call it using
 [`wallet_requestPermssions`](#walletrequestpermissions).
 Under the hood, permissions are plain, JSON-compatible objects, with fields that are mostly used
 internally by MetaMask.
@@ -112,8 +112,6 @@ If the caller has no permissions, the array is empty.
 ### wallet_requestPermissions
 
 Requests [permissions](#restricted-methods) from the user.
-Currently only [`eth_accounts`](https://metamask.github.io/api-playground/api-documentation/#eth_accounts)
-requires requesting permission.
 
 The request causes a MetaMask popup to appear.
 You should only request permissions in response to a direct user action, such as a button click.


### PR DESCRIPTION
Document `wallet_snap` in place of `wallet_snap_*`, and update some related permissions content. Fixes #68.

Preview: https://metamask.github.io/mm-docs-v2/68-wallet-snap/snaps/reference/rpc-api#wallet_snap