### PR TITLE
Restructure SDK how-tos

### DIFF
--- a/wallet-sidebar.js
+++ b/wallet-sidebar.js
@@ -31,8 +31,23 @@ const sidebar = {
             id: "how-to/use-sdk/index",
           },
           items: [
-            "how-to/use-sdk/react-native",
-            "how-to/use-sdk/pure-js",
+            {
+              type: "category",
+              label: "JavaScript",
+              collapsed: true,
+              link: {
+                type: "doc",
+                id: "how-to/use-sdk/javascript/index",
+              },
+              items: [
+                "how-to/use-sdk/javascript/react",
+                "how-to/use-sdk/javascript/pure-js",
+                "how-to/use-sdk/javascript/other-web-frameworks",
+                "how-to/use-sdk/javascript/react-native",
+                "how-to/use-sdk/javascript/nodejs",
+                "how-to/use-sdk/javascript/electron",
+              ],
+            },
             "how-to/use-sdk/ios",
             "how-to/use-sdk/unity",
           ],

--- a/wallet/how-to/use-sdk/index.md
+++ b/wallet/how-to/use-sdk/index.md
@@ -1,115 +1,30 @@
 # Use MetaMask SDK
 
-MetaMask SDK currently supports all JavaScript-based, native iOS, and Unity gaming dapps.
+MetaMask SDK currently supports all JavaScript-based, native iOS, and Unity dapps.
 It provides a reliable, secure, and seamless [connection](../../concepts/sdk-connections.md) from
 your dapp to a MetaMask wallet client.
 
-The following instructions work for dapps based on standard JavaScript, React, Node.js, Electron,
-and other web frameworks.
-You can also see instructions for [React Native](react-native.md), [pure JavaScript](pure-js.md),
-[native iOS](ios.md), and [Unity gaming](unity.md) dapps.
+You can see instructions for using the SDK with the following platforms:
+
+- JavaScript:
+  - Web dapps:
+    - [React](javascript/react.md)
+    - [Pure JavaScript](javascript/pure-js.md)
+    - [Other web frameworks](javascript/other-web-frameworks.md)
+  - [React Native](javascript/react-native.md)
+  - [Node.js](javascript/nodejs.md)
+  - [Electron](javascript/electron.md)
+- Mobile:
+  - [React Native](javascript/react-native.md)
+  - [native iOS](ios.md)
+- Gaming:
+  - [Unity](unity.md)
 
 :::tip Coming soon
-SDK support for Android and Unreal Engine dapps is coming soon.
+SDK support for Android and Unreal Engine is coming soon.
 :::
 
 :::note
 MetaMask SDK uses the [Ethereum provider](../../reference/provider-api.md) that developers are
 already used to, so existing dapps work out of the box with the SDK.
 :::
-
-## How it works
-
-<!--tabs-->
-
-# Desktop browser
-
-If a user accesses your web dapp on a desktop browser and doesn't have the MetaMask extension
-installed, a popup appears that prompts the user to either install the MetaMask extension or connect
-to MetaMask Mobile using a QR code.
-
-![SDK desktop browser example](../../assets/sdk-desktop-browser.gif)
-
-You can try the
-[hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
-You can also see this
-[React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
-
-# Mobile browser
-
-If a user accesses your web dapp on a mobile browser, the SDK automatically deeplinks to MetaMask
-Mobile (or if the user doesn't already have it, prompts them to install it).
-Once the user accepts the connection, they're automatically redirected back to your dapp.
-This happens for all actions that need user approval.
-
-<p align="center">
-
-![SDK mobile browser example](../../assets/sdk-mobile-browser.gif)
-
-</p>
-
-You can try the
-[hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
-You can also see this
-[React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
-
-# Node.js
-
-When a user accesses your Node.js dapp, the SDK renders a QR code on the console which users can
-scan with their MetaMask Mobile app.
-
-<p align="center">
-
-![SDK Node.js example](../../assets/sdk-nodejs.gif)
-
-</p>
-
-<!--/tabs-->
-
-## Prerequisites
-
-- An existing or [new project](../../get-started/set-up-dev-environment.md) set up.
-- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above.
-- [Yarn](https://yarnpkg.com/getting-started/install) or
-  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
-
-## Steps
-
-### 1. Install the SDK
-
-In your project directory, install the SDK using Yarn or npm:
-
-```bash
-yarn add @metamask/sdk
-or
-npm i @metamask/sdk
-```
-
-### 2. Import the SDK
-
-In your project script, add the following to import the SDK:
-
-```javascript
-import MetaMaskSDK from '@metamask/sdk';
-```
-
-### 3. Instantiate the SDK
-
-Instantiate the SDK using any [options](../../reference/sdk-js-options.md):
-
-```javascript
-const MMSDK = new MetaMaskSDK(options);
-
-const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
-```
-
-### 4. Use the SDK
-
-Use the SDK by calling any [provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#eth_requestaccounts) using
-[`ethereum.request()`](../../reference/provider-api.md#ethereumrequestargs) first, since it prompts
-the installation or connection popup to appear.
-
-```javascript
-ethereum.request({ method: 'eth_requestAccounts', params: [] });
-```

--- a/wallet/how-to/use-sdk/javascript/electron.md
+++ b/wallet/how-to/use-sdk/javascript/electron.md
@@ -1,0 +1,51 @@
+---
+title: Electron
+---
+
+# Use MetaMask SDK with Electron
+
+You can import MetaMask SDK into your Electron dapp to enable your users to easily connect with
+their MetaMask Mobile wallet.
+The SDK for Electron [works the same way](index.md#how-it-works) and has the
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/index.md
+++ b/wallet/how-to/use-sdk/javascript/index.md
@@ -1,0 +1,100 @@
+# Use MetaMask SDK with JavaScript
+
+You can import MetaMask SDK into your JavaScript dapp to enable your users to easily connect
+with their MetaMask Mobile wallet.
+
+The following instructions work for web dapps based on standard JavaScript.
+You can also see instructions for the following JavaScript-based platforms:
+
+- Web dapps:
+  - [React](react.md)
+  - [Pure JavaScript](pure-js.md)
+  - [Other web frameworks](other-web-frameworks.md)
+- [React Native](react-native.md)
+- [Node.js](nodejs.md)
+- [Electron](electron.md)
+
+## How it works
+
+<!--tabs-->
+
+# Desktop browser
+
+If a user accesses your web dapp on a desktop browser and doesn't have the MetaMask extension
+installed, a popup appears that prompts the user to either install the MetaMask extension or connect
+to MetaMask Mobile using a QR code.
+
+![SDK desktop browser example](../../../assets/sdk-desktop-browser.gif)
+
+You can try the
+[hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
+You can also see this
+[React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
+
+# Mobile browser
+
+If a user accesses your web dapp on a mobile browser, the SDK automatically deeplinks to MetaMask
+Mobile (or if the user doesn't already have it, prompts them to install it).
+Once the user accepts the connection, they're automatically redirected back to your dapp.
+This happens for all actions that need user approval.
+
+<p align="center">
+
+![SDK mobile browser example](../../../assets/sdk-mobile-browser.gif)
+
+</p>
+
+You can try the
+[hosted test dapp with the SDK installed](https://c0f4f41c-2f55-4863-921b-sdk-docs.github.io/test-dapp-2/).
+You can also see this
+[React project example](https://github.com/MetaMask/examples/tree/main/metamask-with/metamask-sdk-create-react-app).
+
+<!--/tabs-->
+
+## Prerequisites
+
+- An existing or [new project](../../../get-started/set-up-dev-environment.md) set up.
+- [MetaMask Mobile](https://github.com/MetaMask/metamask-mobile) v5.8.1 or above.
+- [Yarn](https://yarnpkg.com/getting-started/install) or
+  [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/nodejs.md
+++ b/wallet/how-to/use-sdk/javascript/nodejs.md
@@ -1,0 +1,61 @@
+---
+title: Node.js
+---
+
+# Use MetaMask SDK with Node.js
+
+You can import MetaMask SDK into your Node.js dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for Node.js has the [same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## How it works
+
+When a user accesses your Node.js dapp, the SDK renders a QR code on the console which users can
+scan with their MetaMask Mobile app.
+
+<p align="center">
+
+![SDK Node.js example](../../../assets/sdk-nodejs.gif)
+
+</p>
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
+++ b/wallet/how-to/use-sdk/javascript/other-web-frameworks.md
@@ -1,0 +1,51 @@
+---
+title: Other web frameworks
+---
+
+# Use MetaMask SDK with other web frameworks
+
+You can import MetaMask SDK into your web dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for other web frameworks [works the same way](index.md#how-it-works) and has the
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```

--- a/wallet/how-to/use-sdk/javascript/pure-js.md
+++ b/wallet/how-to/use-sdk/javascript/pure-js.md
@@ -7,7 +7,7 @@ title: Pure JavaScript
 You can import MetaMask SDK into your pure JavaScript dapp to enable your users to easily connect
 with a MetaMask wallet client.
 The SDK for pure JavaScript [works the same way](index.md#how-it-works) and has the
-[same prerequisites](index.md#prerequisites) as for standard JavaScript and other web frameworks.
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
 
 To import, instantiate, and use the SDK, you can insert a script in the head section of your website:
 
@@ -31,8 +31,8 @@ To import, instantiate, and use the SDK, you can insert a script in the head sec
 </head>
 ```
 
-You can configure the SDK using any [options](../../reference/sdk-js-options.md) and call any
-[provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#eth_requestaccounts) using
-[`ethereum.request()`](../../reference/provider-api.md#ethereumrequestargs) first, since it prompts
+You can configure the SDK using any [options](../../../reference/sdk-js-options.md) and call any
+[provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it prompts
 the installation or connection popup to appear.

--- a/wallet/how-to/use-sdk/javascript/react-native.md
+++ b/wallet/how-to/use-sdk/javascript/react-native.md
@@ -16,7 +16,7 @@ This happens for all actions that need user approval.
 
 <p align="center">
 
-![SDK React Native example](../../assets/sdk-react-native.gif)
+![SDK React Native example](../../../assets/sdk-react-native.gif)
 
 </p>
 
@@ -125,10 +125,10 @@ const ethereum = MMSDK.getProvider();
 const accounts = await ethereum.request({ method: 'eth_requestAccounts' });
 ```
 
-You can configure the SDK using any [options](../../reference/sdk-js-options.md) and call any
-[provider API methods](../../reference/provider-api.md).
-Always call [`eth_requestAccounts`](../../reference/rpc-api.md#ethrequestaccounts) using
-[`ethereum.request()`](../../reference/provider-api.md#windowethereumrequest--args-) first, since it
+You can configure the SDK using any [options](../../../reference/sdk-js-options.md) and call any
+[provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#ethrequestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#windowethereumrequest--args-) first, since it
 prompts the installation or connection popup to appear.
 
 You can use [EthersJS](https://docs.ethers.io/v5/getting-started/) with your React Native app:

--- a/wallet/how-to/use-sdk/javascript/react.md
+++ b/wallet/how-to/use-sdk/javascript/react.md
@@ -1,0 +1,51 @@
+---
+title: React
+---
+
+# Use MetaMask SDK with React
+
+You can import MetaMask SDK into your React dapp to enable your users to easily connect with their
+MetaMask Mobile wallet.
+The SDK for React [works the same way](index.md#how-it-works) and has the
+[same prerequisites](index.md#prerequisites) as for standard JavaScript.
+
+## Steps
+
+### 1. Install the SDK
+
+In your project directory, install the SDK using Yarn or npm:
+
+```bash
+yarn add @metamask/sdk
+or
+npm i @metamask/sdk
+```
+
+### 2. Import the SDK
+
+In your project script, add the following to import the SDK:
+
+```javascript
+import MetaMaskSDK from '@metamask/sdk';
+```
+
+### 3. Instantiate the SDK
+
+Instantiate the SDK using any [options](../../../reference/sdk-js-options.md):
+
+```javascript
+const MMSDK = new MetaMaskSDK(options);
+
+const ethereum = MMSDK.getProvider(); // You can also access via window.ethereum
+```
+
+### 4. Use the SDK
+
+Use the SDK by calling any [provider API methods](../../../reference/provider-api.md).
+Always call [`eth_requestAccounts`](../../../reference/rpc-api.md#eth_requestaccounts) using
+[`ethereum.request()`](../../../reference/provider-api.md#ethereumrequestargs) first, since it
+prompts the installation or connection popup to appear.
+
+```javascript
+ethereum.request({ method: 'eth_requestAccounts', params: [] });
+```


### PR DESCRIPTION
Restructure SDK to have separate how-to page for each platform. This structure has pages with duplicate instructions but more clearly lays out which platforms the SDK supports.